### PR TITLE
Add is_primary and other new Calendar attributes

### DIFF
--- a/lib/nylas/calendar.rb
+++ b/lib/nylas/calendar.rb
@@ -15,11 +15,18 @@ module Nylas
 
     attribute :name, :string
     attribute :description, :string
+    attribute :is_primary, :boolean
+    attribute :location, :string
+    attribute :timezone, :string
 
     attribute :read_only, :boolean
 
     def read_only?
       read_only == true
+    end
+
+    def primary?
+      is_primary
     end
 
     def events


### PR DESCRIPTION
Adds support for `is_primary`, `location` and `timezone` attributes to the Calendar model.