### PR TITLE
No longer warn of undefined attributes

### DIFF
--- a/lib/nylas/model/attributable.rb
+++ b/lib/nylas/model/attributable.rb
@@ -27,8 +27,6 @@ module Nylas
         data.each do |attribute_name, value|
           if respond_to?(:"#{attribute_name}=")
             send(:"#{attribute_name}=", value)
-          else
-            Logging.logger.warn("#{attribute_name} is not defined as an attribute on #{self.class.name}")
           end
         end
       end


### PR DESCRIPTION
Per Nylas API docs, new attributes can be added at any time without a version change. This change stops polluting application logs with warnings once new attributes are added.